### PR TITLE
fix the directory problem when loading the map

### DIFF
--- a/src/av2/map/map_api.py
+++ b/src/av2/map/map_api.py
@@ -372,7 +372,7 @@ class ArgoverseStaticMap:
         vector_data_fnames = sorted(log_map_dirpath.glob("log_map_archive_*.json"))
         if not len(vector_data_fnames) == 1:
             raise RuntimeError(f"JSON file containing vector map data is missing (searched in {log_map_dirpath})")
-        vector_data_fname = vector_data_fnames[0]
+        vector_data_fname = vector_data_fnames[0].name
 
         vector_data_json_path = log_map_dirpath / vector_data_fname
         static_map = cls.from_json(vector_data_json_path)


### PR DESCRIPTION
## PR Summary

The 'WindowPath' object of the map .json file , would load the whole directory once again when loading the map, which render the directory wrong., like issue #102 
Instead only the file name should be taken, with `.name` simply

## Testing

The change is minimal. The tutorial notebook works now.

In order to ensure this PR works as intended, it is:

* [ ] unit tested.
* [ ] other or not applicable (*additional detail/rationale required*)

## Compliance with Standards
<!-- Authors: Check each item below to certify that this PR is ready for review. -->

As the author, I certify that this PR conforms to the following standards:

* [ x] Code changes conform to [PEP8](https://www.python.org/dev/peps/pep-0008) and docstrings conform to the Google Python [style guide](https://google.github.io/styleguide/pyguide.html?showone=Comments#38-comments-and-docstrings).
* [ x] A well-written summary explains what was done and why it was done.
* [ ] The PR is adequately tested and the testing details and links to external results are included.

<!-- Authors: If this PR is not ready for review, please create a "Draft Pull Request" using the dropdown below. -->