### PR TITLE
fix:tracking evaluation

### DIFF
--- a/src/av2/evaluation/tracking/eval.py
+++ b/src/av2/evaluation/tracking/eval.py
@@ -83,7 +83,10 @@ class TrackEvalDataset(_BaseDataset):  # type: ignore
 
         raw_data = {
             f"{source}_ids": [frame["track_id"] for frame in tracks],
-            f"{source}_classes": [frame["label"] for frame in tracks],
+            f"{source}_classes": [
+                np.array([self.full_class_list.index(n) for n in frame["name"]])
+                for frame in tracks
+            ],
             f"{source}_dets": [
                 np.concatenate((frame["translation_m"], frame["size"]), axis=-1)
                 for frame in tracks


### PR DESCRIPTION
## PR Summary
Currently tracking evaluation uses the class label id to match classes between prediction and ground truth tracks. This label id is defined based on the order of class names in the av2 repository. However, label ids could easily be misdefined in the predictions, eg. the [LT3D](https://github.com/neeharperi/LT3D/tree/main) repository uses label ids in a different order. This change uses the text array `name` instead of `label` id to match classes in evaluation.

## Testing
<!-- Authors: Add testing details here, explaining your overall strategy, and check the applicable boxes below. -->

In order to ensure this PR works as intended, it is:

* [ ] unit tested.
* [x] other or not applicable (*additional detail/rationale required*)

Tested with example tracking predictions that uses a different label id ordering.

## Compliance with Standards
<!-- Authors: Check each item below to certify that this PR is ready for review. -->

As the author, I certify that this PR conforms to the following standards:

* [x] Code changes conform to [PEP8](https://www.python.org/dev/peps/pep-0008) and docstrings conform to the Google Python [style guide](https://google.github.io/styleguide/pyguide.html?showone=Comments#38-comments-and-docstrings).
* [x] A well-written summary explains what was done and why it was done.
* [x] The PR is adequately tested and the testing details and links to external results are included.

<!-- Authors: If this PR is not ready for review, please create a "Draft Pull Request" using the dropdown below. -->