### PR TITLE
Fix scenario mining evaluation bug

### DIFF
--- a/src/av2/evaluation/scenario_mining/eval.py
+++ b/src/av2/evaluation/scenario_mining/eval.py
@@ -2,8 +2,8 @@
 
 Evaluation Metrics:
     HOTA: see https://arxiv.org/abs/2009.07736
-    scenario-level F1: see https://jivp-eurasipjournals.springeropen.com/articles/10.1155/2008/246309
-    timestamp-level F1: see https://arxiv.org/abs/2008.08063
+    scenario-level F1
+    timestamp-level F1
 """
 
 from pathlib import Path
@@ -251,8 +251,8 @@ def compute_temporal_metrics(
         output_dir: The directory to save the plotted confusion matrices.
 
     Returns:
-        timestamp_f1: The F1 score where each timestamp counts as a prediction to evaluate.
         scenario_f1: The F1 score where each log-prompt pair counts as a prediction to evaluate.
+        timestamp_f1: The F1 score where each timestamp counts as a prediction to evaluate.
 
 
     """
@@ -364,7 +364,7 @@ def evaluate(
     output_dir = out + "/partial_tracks"
     Path(output_dir).mkdir(parents=True, exist_ok=True)
 
-    partial_track_hota, timestamp_f1, scenario_f1 = evaluate_scenario_mining(
+    partial_track_hota, scenario_f1, timestamp_f1 = evaluate_scenario_mining(
         track_predictions,
         labels,
         objective_metric=objective_metric,
@@ -421,8 +421,8 @@ def evaluate_scenario_mining(
 
     Returns:
         referred_hota: The HOTA tracking metric applied to all objects with the category REFERRED_OBJECT
-        timestamp_f1: A retrieval/classification metric for determining if each timestamp contains any instance of the prompt.
         scenario_f1: A retrieval/classification metric for determining if each data log contains any instance of the prompt.
+        timestamp_f1: A retrieval/classification metric for determining if each timestamp contains any instance of the prompt.
     """
     classes = list(AV2_CATEGORIES)
 


### PR DESCRIPTION
## PR Summary
<!-- Authors: Add a description immediately below this line, explaining what was done and why it was done, and check the applicable boxes below. -->
Super simple fix to change the indices for scenario mining evaluation metrics. This is done so that the correct score is printed for the correct metric and so that the EvalAI leaderboard is reported correctly. 

## Testing
<!-- Authors: Add testing details here, explaining your overall strategy, and check the applicable boxes below. -->
The previous test case reported the max score of 1.0 for both metrics, which is why the bug slipped through. This was caught after hand-verifying the using the output confusion matrices.

In order to ensure this PR works as intended, it is:

* [✅ ] unit tested.
* [ ✅] other or not applicable (*additional detail/rationale required*)

## Compliance with Standards
<!-- Authors: Check each item below to certify that this PR is ready for review. -->
This change does not appear to pass the linters. This is strange because it is such a minor change. I assume that the linters have been updated since the previous pull request.


As the author, I certify that this PR conforms to the following standards:

* [✅ ] Code changes conform to [PEP8](https://www.python.org/dev/peps/pep-0008) and docstrings conform to the Google Python [style guide](https://google.github.io/styleguide/pyguide.html?showone=Comments#38-comments-and-docstrings).
* [✅ ] A well-written summary explains what was done and why it was done.
* [✅ ] The PR is adequately tested and the testing details and links to external results are included.

<!-- Authors: If this PR is not ready for review, please create a "Draft Pull Request" using the dropdown below. -->